### PR TITLE
chore: decouple config and factory from manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ classDiagram
     }
 
     class DriverFactoryInterface {
-        +driverID()
-        +createDriver()
+        +DriverID()
+        +CreateDriver()
     }
     
     Logger --> DriverManager : "Sends log data"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ classDiagram
     class Logger {
         +NewLog(manager: DriverManager)
         +log(...)
-        +beginTx(...) TxID
+        +BeginTx(...) TxID
         +logTx(txID, ...) 
         +endTx(txID)
     }
@@ -59,7 +59,7 @@ classDiagram
     class DriverInterface {
         <<Interface>>
         +logData(...)
-        +beginTx()
+        +BeginTx()
         +endTx(txID)
         +configure(jsonConfig)
     }

--- a/config_loader.go
+++ b/config_loader.go
@@ -1,0 +1,53 @@
+package logsystem
+
+import "errors"
+
+type failedDriver struct {
+	id  DriverID
+	err error
+}
+
+var (
+	ErrorAllDriversFailed  = errors.New("all drivers failed to initialize")
+	ErrorSomeDriversFailed = errors.New("some drivers failed to initialize")
+)
+
+func CreateLogManagerWithConfig(factories []DriverFactoryInterface, config Config) (*DriverManager, error) {
+	drivers, failedDrivers := matchConfigWithDrivers(factories, config)
+	if (len(drivers) == 0) && (len(failedDrivers) > 0) {
+		return nil, ErrorAllDriversFailed
+	}
+	mgr := NewManager()
+	mgr.AddDrivers(drivers)
+	if len(failedDrivers) > 0 {
+		for _, failedDriver := range failedDrivers {
+			mgr.log(map[Param]string{
+				"driver_id": string(failedDriver.id),
+				"error":     failedDriver.err.Error(),
+			})
+		}
+		return mgr, ErrorSomeDriversFailed
+	}
+	return mgr, nil
+}
+
+func matchConfigWithDrivers(factories []DriverFactoryInterface, config Config) (drivers []DriverInterface, failedDrivers []failedDriver) {
+	failedDrivers = make([]failedDriver, 0)
+	drivers = make([]DriverInterface, 0)
+
+	for _, factory := range factories {
+		if _, ok := config.Drivers[factory.DriverID()]; ok {
+			driver, crErr := factory.CreateDriver(config.Drivers[factory.DriverID()])
+			if crErr != nil {
+				failedDrivers = append(failedDrivers, failedDriver{
+					id:  factory.DriverID(),
+					err: crErr,
+				})
+				continue
+			}
+			drivers = append(drivers, driver)
+		}
+	}
+
+	return drivers, failedDrivers
+}

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -34,19 +34,19 @@ func (f *SuccessDriverFactory) CreateDriver(config json.RawMessage) (DriverInter
 	return &SuccessDriverFactory{}, nil
 }
 
-func (f *SuccessDriverFactory) beginTx(id TxID, attr map[Param]string) {
+func (f *SuccessDriverFactory) BeginTx(id TxID, attr map[Param]string) {
 	panic("Not expected to be called")
 }
 
-func (f *SuccessDriverFactory) endTx(txID TxID) {
+func (f *SuccessDriverFactory) EndTx(txID TxID) {
 	panic("Not expected to be called")
 }
 
-func (f *SuccessDriverFactory) log(map[Param]string) {
+func (f *SuccessDriverFactory) Log(map[Param]string) {
 	f.failCounts += 1
 }
 
-func (f *SuccessDriverFactory) stop() {
+func (f *SuccessDriverFactory) Stop() {
 	panic("Not expected to be called")
 }
 
@@ -163,8 +163,8 @@ func TestConfigLoaderIntegration(t *testing.T) {
 	}
 
 	for _, mockDriver := range mockDrivers {
-		mockDriver.On("log", simpleLogPayload).Once()
-		mockDriver.On("beginTx", mock.AnythingOfType("logsystem.TxID"), mock.AnythingOfType("map[logsystem.Param]string")).Once()
+		mockDriver.On("Log", simpleLogPayload).Once()
+		mockDriver.On("BeginTx", mock.AnythingOfType("logsystem.TxID"), mock.AnythingOfType("map[logsystem.Param]string")).Once()
 	}
 	manager.log(simpleLogPayload)
 	txID := manager.beginTx(map[Param]string{})
@@ -173,9 +173,9 @@ func TestConfigLoaderIntegration(t *testing.T) {
 		TxIDParam: txID.String(),
 	}
 	for _, mockDriver := range mockDrivers {
-		mockDriver.On("log", txLogPayload).Once()
-		mockDriver.On("endTx", txID).Once()
-		mockDriver.On("stop").Once()
+		mockDriver.On("Log", txLogPayload).Once()
+		mockDriver.On("EndTx", txID).Once()
+		mockDriver.On("Stop").Once()
 	}
 	manager.log(txLogPayload)
 	manager.endTx(txID)

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -1,0 +1,195 @@
+package logsystem
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type FailingDriverFactory struct {
+}
+
+func (f *FailingDriverFactory) DriverID() DriverID {
+	return "failing"
+}
+
+func (f *FailingDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
+	return nil, errors.New("failed to create driver")
+}
+
+type SuccessDriverFactory struct {
+	failCounts int
+}
+
+func (f *SuccessDriverFactory) DriverID() DriverID {
+	return "success"
+}
+
+func (f *SuccessDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
+	return &SuccessDriverFactory{}, nil
+}
+
+func (f *SuccessDriverFactory) beginTx(id TxID, attr map[Param]string) {
+	panic("Not expected to be called")
+}
+
+func (f *SuccessDriverFactory) endTx(txID TxID) {
+	panic("Not expected to be called")
+}
+
+func (f *SuccessDriverFactory) log(map[Param]string) {
+	f.failCounts += 1
+}
+
+func (f *SuccessDriverFactory) stop() {
+	panic("Not expected to be called")
+}
+
+func TestConfigLoader_FailToCreateDriver(t *testing.T) {
+	m, err := CreateLogManagerWithConfig(
+		[]DriverFactoryInterface{
+			&FailingDriverFactory{},
+		},
+		Config{
+			Drivers: map[DriverID]json.RawMessage{
+				"failing": json.RawMessage(`{}`),
+			},
+		},
+	)
+	require.ErrorIs(t, err, ErrorAllDriversFailed)
+	require.Nil(t, m)
+}
+
+func TestConfigLoader_PartiallyFailToCreateDriver(t *testing.T) {
+	m, err := CreateLogManagerWithConfig(
+		[]DriverFactoryInterface{
+			&FailingDriverFactory{},
+			&SuccessDriverFactory{},
+		},
+		Config{
+			Drivers: map[DriverID]json.RawMessage{
+				"failing": json.RawMessage(`{}`),
+				"success": json.RawMessage(`{}`),
+			},
+		},
+	)
+	require.ErrorIs(t, err, ErrorSomeDriversFailed)
+	require.Len(t, m.drivers, 1)
+	require.Equal(t, 1, m.drivers[0].(*SuccessDriverFactory).failCounts)
+}
+
+func TestConfigLoader_SuccessfullyCreateDriver(t *testing.T) {
+	m, err := CreateLogManagerWithConfig(
+		[]DriverFactoryInterface{
+			&SuccessDriverFactory{},
+		},
+		Config{
+			Drivers: map[DriverID]json.RawMessage{
+				"success": json.RawMessage(`{}`),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, m.drivers, 1)
+}
+
+// MockDriverFactory mocks DriverFactoryInterface
+type MockDriverFactory struct {
+	mock.Mock
+	mockDriver *MockDriver
+}
+
+func NewMockDriverFactory(mockDriver *MockDriver) *MockDriverFactory {
+	return &MockDriverFactory{mockDriver: mockDriver}
+}
+
+func (m *MockDriverFactory) DriverID() DriverID {
+	args := m.Called()
+	return args.Get(0).(DriverID)
+}
+
+func (m *MockDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
+	m.Called(config)
+	return m.mockDriver, nil
+}
+
+// TestConfigLoaderIntegration tests the integration of the DriverManager with the DriverFactoryInterface
+func TestConfigLoaderIntegration(t *testing.T) {
+	// Prepare dummy driver and factory
+	//
+
+	dummyConfig := json.RawMessage{}
+	err := dummyConfig.UnmarshalJSON([]byte(`{"key":"value"}`))
+	require.NoError(t, err)
+
+	mockDrivers := make([]*MockDriver, 0)
+	mockFactories := make([]DriverFactoryInterface, 0)
+	for i := 0; i < 2; i++ {
+		mockDriver := &MockDriver{}
+
+		mockDrivers = append(mockDrivers, mockDriver)
+
+		mockID := DriverID("mockID" + strconv.Itoa(i))
+		mockFactory := NewMockDriverFactory(mockDriver)
+		mockFactory.On("DriverID").Return(mockID)
+		mockFactory.On("CreateDriver", dummyConfig).Return(mockDriver)
+
+		mockFactories = append(mockFactories, mockFactory)
+	}
+
+	// Call manager API and validate expectations
+	//
+
+	manager, err := CreateLogManagerWithConfig(mockFactories, Config{
+		Drivers: map[DriverID]json.RawMessage{
+			mockFactories[0].DriverID(): dummyConfig,
+			mockFactories[1].DriverID(): dummyConfig,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(manager.drivers))
+	require.Equal(t, 2, len(mockDrivers))
+
+	simpleLogPayload := map[Param]string{
+		TimeParam:      strconv.FormatInt(time.Now().Unix(), 10),
+		MessageParam:   "message",
+		LevelParam:     "info",
+		ComponentParam: "component",
+	}
+
+	for _, mockDriver := range mockDrivers {
+		mockDriver.On("log", simpleLogPayload).Once()
+		mockDriver.On("beginTx", mock.AnythingOfType("logsystem.TxID"), mock.AnythingOfType("map[logsystem.Param]string")).Once()
+	}
+	manager.log(simpleLogPayload)
+	txID := manager.beginTx(map[Param]string{})
+
+	txLogPayload := map[Param]string{
+		TxIDParam: txID.String(),
+	}
+	for _, mockDriver := range mockDrivers {
+		mockDriver.On("log", txLogPayload).Once()
+		mockDriver.On("endTx", txID).Once()
+		mockDriver.On("stop").Once()
+	}
+	manager.log(txLogPayload)
+	manager.endTx(txID)
+
+	manager.stop()
+
+	// Validate expectations for all mocks
+	//
+
+	for _, mockFactoryIf := range mockFactories {
+		mockFactory := mockFactoryIf.(*MockDriverFactory)
+		mockFactory.AssertExpectations(t)
+	}
+	for _, mockDriver := range mockDrivers {
+		mockDriver.AssertExpectations(t)
+	}
+}

--- a/console_driver.go
+++ b/console_driver.go
@@ -36,27 +36,27 @@ type ConsoleDriver struct {
 	config consoleConfig
 }
 
-func (d *ConsoleDriver) log(data map[Param]string) {
+func (d *ConsoleDriver) Log(data map[Param]string) {
 	line := formatLine(data, d.config.UserReadableTime)
 	fmt.Println(line)
 }
 
-func (d *ConsoleDriver) beginTx(id TxID, attr map[Param]string) {
+func (d *ConsoleDriver) BeginTx(id TxID, attr map[Param]string) {
 	txData := make(map[Param]string)
 	txData[TxIDParam] = id.String()
 	message := fmt.Sprintf("TX Begin; Params: %v", attr)
 	txData[MessageParam] = message
 	txData[LevelParam] = string(Info)
-	d.log(txData)
+	d.Log(txData)
 }
 
-func (d *ConsoleDriver) endTx(id TxID) {
+func (d *ConsoleDriver) EndTx(id TxID) {
 	txData := make(map[Param]string)
 	txData[TxIDParam] = id.String()
 	txData[MessageParam] = "TX End"
 	txData[LevelParam] = string(Info)
-	d.log(txData)
+	d.Log(txData)
 }
 
-func (d *ConsoleDriver) stop() {
+func (d *ConsoleDriver) Stop() {
 }

--- a/console_driver.go
+++ b/console_driver.go
@@ -15,21 +15,20 @@ type consoleConfig struct {
 type ConsoleDriverFactory struct {
 }
 
-func (f *ConsoleDriverFactory) driverID() DriverID {
+func (f *ConsoleDriverFactory) DriverID() DriverID {
 	return DriverID(ConsoleDriverID)
 }
 
-func (f *ConsoleDriverFactory) createDriver(config json.RawMessage) DriverInterface {
+func (f *ConsoleDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
 	var consoleConfig consoleConfig
 	err := json.Unmarshal(config, &consoleConfig)
 	if err != nil {
-		fmt.Printf("Failed to unmarshal console driver config: %v\n", err)
-		return nil
+		return nil, fmt.Errorf("failed to unmarshal console driver config: %w", err)
 	}
 
 	return &ConsoleDriver{
 		config: consoleConfig,
-	}
+	}, nil
 }
 
 // ConsoleDriver implements DriverInterface

--- a/db_driver.go
+++ b/db_driver.go
@@ -98,7 +98,7 @@ func (d *SQLiteDriver) initDB() error {
 	return err
 }
 
-func (d *SQLiteDriver) log(data map[Param]string) {
+func (d *SQLiteDriver) Log(data map[Param]string) {
 	p := extractKnownParams(data)
 
 	_, err := d.db.Exec(`
@@ -111,7 +111,7 @@ func (d *SQLiteDriver) log(data map[Param]string) {
 	}
 }
 
-func (d *SQLiteDriver) beginTx(id TxID, attr map[Param]string) {
+func (d *SQLiteDriver) BeginTx(id TxID, attr map[Param]string) {
 	p := extractKnownParams(attr)
 
 	columns := []string{"start_timestamp", "id"}
@@ -147,7 +147,7 @@ func (d *SQLiteDriver) beginTx(id TxID, attr map[Param]string) {
 	}
 }
 
-func (d *SQLiteDriver) endTx(id TxID) {
+func (d *SQLiteDriver) EndTx(id TxID) {
 	timestamp := time.Now().Unix()
 
 	_, err := d.db.Exec(`
@@ -161,6 +161,6 @@ func (d *SQLiteDriver) endTx(id TxID) {
 	}
 }
 
-func (d *SQLiteDriver) stop() {
+func (d *SQLiteDriver) Stop() {
 	d.db.Close()
 }

--- a/db_driver.go
+++ b/db_driver.go
@@ -3,6 +3,7 @@ package logsystem
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,16 +22,16 @@ type sqliteConfig struct {
 type DBDriverFactory struct {
 }
 
-func (f *DBDriverFactory) driverID() DriverID {
+func (f *DBDriverFactory) DriverID() DriverID {
 	return DriverID(SQLiteDriverID)
 }
 
-func (f *DBDriverFactory) createDriver(config json.RawMessage) DriverInterface {
+func (f *DBDriverFactory) CreateDriver(config json.RawMessage) (drv DriverInterface, err error) {
 	var sqliteConfig sqliteConfig
-	err := json.Unmarshal(config, &sqliteConfig)
+	err = json.Unmarshal(config, &sqliteConfig)
 	if err != nil {
 		fmt.Printf("Failed to unmarshal SQLite driver config: %v\n", err)
-		return nil
+		return nil, errors.Join(errors.New("failed to unmarshal SQLite driver config"), err)
 	}
 
 	driver := &SQLiteDriver{
@@ -39,11 +40,10 @@ func (f *DBDriverFactory) createDriver(config json.RawMessage) DriverInterface {
 
 	err = driver.initDB()
 	if err != nil {
-		fmt.Printf("Failed to initialize SQLite database: %v\n", err)
-		return nil
+		return nil, err
 	}
 
-	return driver
+	return driver, nil
 }
 
 // SQLiteDriver implements DriverInterface

--- a/driver_interface.go
+++ b/driver_interface.go
@@ -13,9 +13,8 @@ func (id TxID) String() string {
 }
 
 type DriverFactoryInterface interface {
-	driverID() DriverID
-	// createDriver returns nil if the driver could not be created and should not be used
-	createDriver(config json.RawMessage) DriverInterface
+	DriverID() DriverID
+	CreateDriver(config json.RawMessage) (DriverInterface, error)
 }
 
 type Param string

--- a/driver_interface.go
+++ b/driver_interface.go
@@ -38,10 +38,10 @@ const (
 
 // DriverInterface interface won't be called if the driver is not created successfully, therefore no need to handle creation errors
 type DriverInterface interface {
-	log(data map[Param]string)
-	beginTx(id TxID, attr map[Param]string)
-	endTx(id TxID)
+	Log(data map[Param]string)
+	BeginTx(id TxID, attr map[Param]string)
+	EndTx(id TxID)
 
 	// shutdown the driver
-	stop()
+	Stop()
 }

--- a/driver_manager.go
+++ b/driver_manager.go
@@ -14,13 +14,17 @@ func NewManager() *DriverManager {
 	return &DriverManager{}
 }
 
+func (m *DriverManager) AddDriver(driver DriverInterface) {
+	m.drivers = append(m.drivers, driver)
+}
+
 func (m *DriverManager) AddDrivers(drivers []DriverInterface) {
 	m.drivers = append(m.drivers, drivers...)
 }
 
 func (m *DriverManager) log(data map[Param]string) {
 	for _, driver := range m.drivers {
-		driver.log(data)
+		driver.Log(data)
 	}
 }
 
@@ -28,19 +32,19 @@ func (m *DriverManager) beginTx(attr map[Param]string) TxID {
 	txID := TxID(m.lastTxID.Add(1))
 
 	for _, driver := range m.drivers {
-		driver.beginTx(txID, attr)
+		driver.BeginTx(txID, attr)
 	}
 	return txID
 }
 
 func (m *DriverManager) endTx(id TxID) {
 	for _, driver := range m.drivers {
-		driver.endTx(id)
+		driver.EndTx(id)
 	}
 }
 
 func (m *DriverManager) stop() {
 	for _, driver := range m.drivers {
-		driver.stop()
+		driver.Stop()
 	}
 }

--- a/driver_manager.go
+++ b/driver_manager.go
@@ -1,7 +1,6 @@
 package logsystem
 
 import (
-	"log"
 	"sync/atomic"
 )
 
@@ -11,22 +10,12 @@ type DriverManager struct {
 	lastTxID atomic.Int64
 }
 
-func NewManager(factories []DriverFactoryInterface, config Config) *DriverManager {
-	drivers := make([]DriverInterface, 0, len(factories))
-	for _, factory := range factories {
-		if _, ok := config.Drivers[factory.driverID()]; ok {
-			driver := factory.createDriver(config.Drivers[factory.driverID()])
-			if driver == nil {
-				log.Printf("Failed to create driver %s", factory.driverID())
-				continue
-			}
-			drivers = append(drivers, driver)
-		}
-	}
+func NewManager() *DriverManager {
+	return &DriverManager{}
+}
 
-	return &DriverManager{
-		drivers: drivers,
-	}
+func (m *DriverManager) AddDrivers(drivers []DriverInterface) {
+	m.drivers = append(m.drivers, drivers...)
 }
 
 func (m *DriverManager) log(data map[Param]string) {

--- a/driver_manager_test.go
+++ b/driver_manager_test.go
@@ -1,32 +1,13 @@
 package logsystem
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type FailingDriverFactory struct {
-}
-
-func (f *FailingDriverFactory) driverID() DriverID {
-	return "failing"
-}
-
-func (f *FailingDriverFactory) createDriver(config json.RawMessage) DriverInterface {
-	return nil
-}
-
-func TestDriverManager_FailToCreateDriver(t *testing.T) {
-	m := NewManager([]DriverFactoryInterface{
-		&FailingDriverFactory{},
-	}, Config{})
-	require.Len(t, m.drivers, 0)
-}
-
 func TestDriverManager_beginTx(t *testing.T) {
-	m := NewManager(nil, Config{})
+	m := NewManager()
 	txID := m.beginTx(map[Param]string{})
 	require.Equal(t, TxID(1), txID)
 	txID = m.beginTx(map[Param]string{})

--- a/example/example.go
+++ b/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"logsystem"
 	"logsystem/example/helpers"
 	"os"
@@ -12,7 +13,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	l := logsystem.NewLogger(conf)
+	m, err := logsystem.CreateLogManagerWithConfig(
+		[]logsystem.DriverFactoryInterface{
+			&logsystem.ConsoleDriverFactory{},
+			&logsystem.FileDriverFactory{},
+			&logsystem.DBDriverFactory{},
+		},
+		conf,
+	)
+	if err != nil {
+		if err != logsystem.ErrorSomeDriversFailed {
+			os.Exit(1)
+		}
+		fmt.Println("Some drivers failed to initialize; check logs for details")
+	}
+
+	l := logsystem.NewLogger(m)
 	defer l.Stop()
 	l.Info("Hello, world!")
 	tl := l.BeginTx(map[logsystem.Param]string{"UserID": "123"})

--- a/example/example.log
+++ b/example/example.log
@@ -1,18 +1,36 @@
-[1726828436] INFO  Hello, world!
-[1726828436] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
-[1726828436] WARN  Doing something in TX; TxID=[1]
-[1726828436] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
-[1726828436] INFO  TX End; TxID=[1]
-[1726828436] DEBUG Outside TX
-[1726828436] WARN  Doing something in TX 2; TxID=[2]
-[1726828436] ERROR Error
-[1726828436] INFO  TX End; TxID=[2]
-[1726828438] INFO  Hello, world!
-[1726828438] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
-[1726828438] WARN  Doing something in TX; TxID=[1]
-[1726828438] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
-[1726828438] INFO  TX End; TxID=[1]
-[1726828438] DEBUG Outside TX
-[1726828438] WARN  Doing something in TX 2; TxID=[2]
-[1726828438] ERROR Error
-[1726828438] INFO  TX End; TxID=[2]
+[1730481776] INFO  Hello, world!
+[1730481776] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
+[1730481776] WARN  Doing something in TX; TxID=[1]
+[1730481776] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
+[1730481776] INFO  TX End; TxID=[1]
+[1730481776] DEBUG Outside TX
+[1730481776] WARN  Doing something in TX 2; TxID=[2]
+[1730481776] ERROR Error
+[1730481776] INFO  TX End; TxID=[2]
+[1730481906] INFO  Hello, world!
+[1730481906] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
+[1730481906] WARN  Doing something in TX; TxID=[1]
+[1730481906] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
+[1730481906] INFO  TX End; TxID=[1]
+[1730481906] DEBUG Outside TX
+[1730481906] WARN  Doing something in TX 2; TxID=[2]
+[1730481906] ERROR Error
+[1730481906] INFO  TX End; TxID=[2]
+[1730481981] INFO  Hello, world!
+[1730481981] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
+[1730481981] WARN  Doing something in TX; TxID=[1]
+[1730481981] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
+[1730481981] INFO  TX End; TxID=[1]
+[1730481981] DEBUG Outside TX
+[1730481981] WARN  Doing something in TX 2; TxID=[2]
+[1730481981] ERROR Error
+[1730481981] INFO  TX End; TxID=[2]
+[1730482031] INFO  Hello, world!
+[1730482031] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
+[1730482031] WARN  Doing something in TX; TxID=[1]
+[1730482031] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
+[1730482031] INFO  TX End; TxID=[1]
+[1730482031] DEBUG Outside TX
+[1730482031] WARN  Doing something in TX 2; TxID=[2]
+[1730482031] ERROR Error
+[1730482031] INFO  TX End; TxID=[2]

--- a/example/example.log
+++ b/example/example.log
@@ -34,3 +34,12 @@
 [1730482031] WARN  Doing something in TX 2; TxID=[2]
 [1730482031] ERROR Error
 [1730482031] INFO  TX End; TxID=[2]
+[1730706158] INFO  Hello, world!
+[1730706158] INFO  TX Begin; Params: map[UserID:123]; TxID=[1]
+[1730706158] WARN  Doing something in TX; TxID=[1]
+[1730706158] INFO  TX Begin; Params: map[UserID:456]; TxID=[2]
+[1730706158] INFO  TX End; TxID=[1]
+[1730706158] DEBUG Outside TX
+[1730706158] WARN  Doing something in TX 2; TxID=[2]
+[1730706158] ERROR Error
+[1730706158] INFO  TX End; TxID=[2]

--- a/example/others/no_config_example.go
+++ b/example/others/no_config_example.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"logsystem"
+)
+
+type CountingDriver struct {
+	lines int
+}
+
+func (d *CountingDriver) Log(data map[logsystem.Param]string) {
+	d.lines++
+}
+
+func (d *CountingDriver) BeginTx(id logsystem.TxID, attr map[logsystem.Param]string) {
+	d.lines++
+}
+
+func (d *CountingDriver) EndTx(id logsystem.TxID) {
+	d.lines++
+}
+
+func (d *CountingDriver) Stop() {
+}
+
+func main() {
+	m := logsystem.NewManager()
+
+	countDriver := &CountingDriver{}
+	serialCouter := logsystem.NewSerialDriver(countDriver)
+	m.AddDriver(serialCouter)
+
+	consoleDriver := &logsystem.ConsoleDriver{}
+	m.AddDriver(consoleDriver)
+
+	l := logsystem.NewLogger(m)
+	l.Info("Hello, world!")
+	tl := l.BeginTx(map[logsystem.Param]string{"UserID": "123"})
+	tl.Warn("Doing something in TX")
+	tl2 := l.BeginTx(map[logsystem.Param]string{"UserID": "456"})
+	tl.EndTx()
+	l.Debug("Outside TX")
+	tl2.Warn("Doing something in TX 2")
+	l.Error("Error")
+	tl2.EndTx()
+	l.Stop()
+
+	defer fmt.Println("Lines logged:", countDriver.lines)
+}

--- a/file_driver.go
+++ b/file_driver.go
@@ -17,27 +17,26 @@ type fileConfig struct {
 type FileDriverFactory struct {
 }
 
-func (f *FileDriverFactory) driverID() DriverID {
+func (f *FileDriverFactory) DriverID() DriverID {
 	return DriverID(FileDriverID)
 }
 
-func (f *FileDriverFactory) createDriver(config json.RawMessage) DriverInterface {
+func (f *FileDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
 	var fileConfig fileConfig
 	err := json.Unmarshal(config, &fileConfig)
 	if err != nil {
-		fmt.Printf("Failed to unmarshal file driver config: %v\n", err)
-		return nil
+		return nil, fmt.Errorf("failed to unmarshal file driver: %w", err)
 	}
 
 	file, err := openFile(fileConfig.FilePath)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to open file: %s; error: %w", fileConfig.FilePath, err)
 	}
 
 	return &FileDriver{
 		file:   file,
 		config: fileConfig,
-	}
+	}, nil
 }
 
 // FileDriver implements DriverInterface

--- a/file_driver.go
+++ b/file_driver.go
@@ -45,29 +45,29 @@ type FileDriver struct {
 	file   *os.File
 }
 
-func (d *FileDriver) log(data map[Param]string) {
+func (d *FileDriver) Log(data map[Param]string) {
 	line := formatLine(data, d.config.UserReadableTime)
 	d.file.WriteString(line + "\n")
 }
 
-func (d *FileDriver) beginTx(id TxID, attr map[Param]string) {
+func (d *FileDriver) BeginTx(id TxID, attr map[Param]string) {
 	txData := make(map[Param]string)
 	txData[TxIDParam] = id.String()
 	message := fmt.Sprintf("TX Begin; Params: %v", attr)
 	txData[MessageParam] = message
 	txData[LevelParam] = string(Info)
-	d.log(txData)
+	d.Log(txData)
 }
 
-func (d *FileDriver) endTx(id TxID) {
+func (d *FileDriver) EndTx(id TxID) {
 	txData := make(map[Param]string)
 	txData[TxIDParam] = id.String()
 	txData[MessageParam] = "TX End"
 	txData[LevelParam] = string(Info)
-	d.log(txData)
+	d.Log(txData)
 }
 
-func (d *FileDriver) stop() {
+func (d *FileDriver) Stop() {
 	if d.file != nil {
 		d.file.Close()
 	}

--- a/logger.go
+++ b/logger.go
@@ -15,18 +15,9 @@ type TxLogger struct {
 	component string
 }
 
-func NewLogger(conf Config) *Logger {
-	factories := []DriverFactoryInterface{
-		&ConsoleDriverFactory{},
-		&FileDriverFactory{},
-		&DBDriverFactory{},
-	}
-	return NewLoggerWithDrivers(conf, factories)
-}
-
-func NewLoggerWithDrivers(conf Config, factories []DriverFactoryInterface) *Logger {
+func NewLogger(m *DriverManager) *Logger {
 	return &Logger{
-		mgr: NewManager(factories, conf),
+		mgr: m,
 	}
 }
 

--- a/serial_driver.go
+++ b/serial_driver.go
@@ -23,12 +23,12 @@ func NewSerialDriverFactory(provider DriverFactoryInterface) *SerialDriverFactor
 	}
 }
 
-func (f *SerialDriverFactory) driverID() DriverID {
-	return DriverID(string(f.provider.driverID()) + SerialDriverIDPostfix)
+func (f *SerialDriverFactory) DriverID() DriverID {
+	return DriverID(string(f.provider.DriverID()) + SerialDriverIDPostfix)
 }
 
-func (f *SerialDriverFactory) createDriver(config json.RawMessage) DriverInterface {
-	return f.provider.createDriver(config)
+func (f *SerialDriverFactory) CreateDriver(config json.RawMessage) (DriverInterface, error) {
+	return f.provider.CreateDriver(config)
 }
 
 // SerialDriver implements DriverInterface

--- a/serial_driver.go
+++ b/serial_driver.go
@@ -37,20 +37,37 @@ type SerialDriver struct {
 	mutex    sync.Mutex
 }
 
-func (d *SerialDriver) log(data map[Param]string) {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-	d.provider.log(data)
+func NewSerialDriver(provider DriverInterface) *SerialDriver {
+	_, ok := provider.(*SerialDriver)
+	if ok {
+		panic("SerialDriver cannot be nested")
+	}
+
+	return &SerialDriver{
+		provider: provider,
+	}
 }
 
-func (d *SerialDriver) beginTx(id TxID, attr map[Param]string) {
+func (d *SerialDriver) Log(data map[Param]string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.provider.beginTx(id, attr)
+	d.provider.Log(data)
 }
 
-func (d *SerialDriver) endTx(id TxID) {
+func (d *SerialDriver) BeginTx(id TxID, attr map[Param]string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.provider.endTx(id)
+	d.provider.BeginTx(id, attr)
+}
+
+func (d *SerialDriver) EndTx(id TxID) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.provider.EndTx(id)
+}
+
+func (d *SerialDriver) Stop() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.provider.Stop()
 }


### PR DESCRIPTION
`5f2db6` - Extract and move code related to `Config` and `DriverFactory` from `DriverManager`
`867e37` - Add example of explicit driver configuration